### PR TITLE
Fix #1: Properly display "month" of "year"

### DIFF
--- a/mycal.sh
+++ b/mycal.sh
@@ -12,9 +12,9 @@ color=$($wd/color.py '$@')
 other_args=$($wd/arg.py "$@")
 
 if [[ " ${args[@]} " =~ " month " ]]; then
-  gcal -s 1 -H $color -q US_AK "$other_args" $(date "+%m %Y")
+  gcal -s 1 -H $color -q US_AK $other_args $(date "+%m %Y")
 elif [[ " ${args[@]} " =~ " year " ]]; then
-  gcal -s 1 -H $color -q US_AK "$other_args" $(date "+%Y")
+  gcal -s 1 -H $color -q US_AK $other_args $(date "+%Y")
 else
-  gcal -s 1 -H $color -q US_AK "$other_args"
+  gcal -s 1 -H $color -q US_AK $other_args
 fi


### PR DESCRIPTION
- Error was simple: quotation marks threw gcal off
    - gcal though "$other_args" was a single string
    - to run properly, must be displayed as multiple strings
- Remove erroneous quotations throughout script
- Closes #1